### PR TITLE
Rebuild 0.0.9 b1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@ source:
   sha256: abebdbb77a7ffa91e46caca35212f5bd39028db9b0a45416b51215c5e7a1b3df
 
 build:
-  number: 0
-  skip: true  # [py<37]
+  number: 1
+  skip: true  # [py<37 or py>310]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -v
 
 requirements:


### PR DESCRIPTION
# 0.0.9 b1
upstream: https://github.com/dtkav/swagger_ui_bundle

## Changes
- Bump build number
- Only build for python < 3.11

## Notes
- The current release is incompatible with Python 3.11 and the repo has been staled for a long time